### PR TITLE
fix(client): limit max height of screenshot thumbnails

### DIFF
--- a/client/src/components/Screenshots/Screenshots.js
+++ b/client/src/components/Screenshots/Screenshots.js
@@ -19,7 +19,7 @@ const Screenshots = ({ screenshots, renderDeleteScreenshotButton }) => {
                 {renderDeleteScreenshotButton &&
                     renderDeleteScreenshotButton(currentScreenshot.id)}
             </div>
-            <div>
+            <div className={styles.thumbnails}>
                 {screenshots.map((screenshot, index) => (
                     <button
                         key={index}

--- a/client/src/components/Screenshots/Screenshots.module.css
+++ b/client/src/components/Screenshots/Screenshots.module.css
@@ -32,3 +32,8 @@
 .otherScreenshotCurrent:focus-visible {
     box-shadow: 0 0 0 3px #2196f37d;
 }
+
+.thumbnails {
+    max-height: 600px;
+    overflow: auto;
+}


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/HUB-126

Makes the list of screenshot thumbnails scrollable in order to better support apps with many screenshots.