### PR TITLE
fix: sort versions by created-date

### DIFF
--- a/server/src/data/getAllAppsByDeveloperId.js
+++ b/server/src/data/getAllAppsByDeveloperId.js
@@ -19,6 +19,7 @@ const getAllAppsByDeveloperId = (id, knex) => {
         .where({
             developer_id: id,
         })
+        .orderBy('version_created_at', 'desc')
 }
 
 module.exports = getAllAppsByDeveloperId

--- a/server/src/data/getAllAppsByLanguage.js
+++ b/server/src/data/getAllAppsByLanguage.js
@@ -19,6 +19,7 @@ const getAllAppsByLanguage = (languageCode, knex) => {
         .where({
             language_code: languageCode,
         })
+        .orderBy('version_created_at', 'desc')
 }
 
 module.exports = getAllAppsByLanguage

--- a/server/src/data/getAppById.js
+++ b/server/src/data/getAppById.js
@@ -26,6 +26,7 @@ const getAppById = async (appId, languageCode, knex) => {
                 app_id: appId,
                 language_code: languageCode,
             })
+            .orderBy('version_created_at', 'desc')
     } catch (err) {
         throw new Error(`Could not get app with id: ${appId}. ${err.message}`)
     }

--- a/server/src/data/getApps.js
+++ b/server/src/data/getApps.js
@@ -56,7 +56,7 @@ const getApps = (
                 })
             }
         })
-        .orderBy('name')
+        .orderBy(['name', { column: 'version_created_at', order: 'desc' }])
 }
 
 module.exports = getApps

--- a/server/src/data/getAppsById.js
+++ b/server/src/data/getAppsById.js
@@ -26,6 +26,7 @@ const getAppsById = async (id, languageCode, knex) => {
                 app_id: id,
                 language_code: languageCode,
             })
+            .orderBy('version_created_at', 'desc')
 
         return apps
     } catch (err) {

--- a/server/src/data/getAppsByIdAndStatus.js
+++ b/server/src/data/getAppsByIdAndStatus.js
@@ -18,6 +18,7 @@ const getAppsByIdAndStatus = (id, status, languageCode, knex) => {
             status,
             language_code: languageCode,
         })
+        .orderBy('version_created_at', 'desc')
 }
 
 module.exports = getAppsByIdAndStatus


### PR DESCRIPTION
This should help with ordering versions in the App Management app. 
It's easier to sort by upload date than semantic version, as that can be done from in the DB-query. 